### PR TITLE
Fix `IdentityProviderException(code: 401)` on accessing Token Endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: ci
+
+on: [push]
+
+jobs:
+  run-phpunit:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: [7.0, 7.1, 7.2, 7.3, 7.4]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: php-actions/composer@v5
+        with:
+          php_version: ${{ matrix.php }}
+
+      - name: PHPUnit Tests
+        uses: php-actions/phpunit@v2
+        with:
+          version: 6
+          php_version: ${{ matrix.php }}
+          bootstrap: vendor/autoload.php
+          args: --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "league/oauth2-client": "^2.2"
+        "league/oauth2-client": ">=2.2.0 <2.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"

--- a/tests/ChatWorkProviderTest.php
+++ b/tests/ChatWorkProviderTest.php
@@ -2,8 +2,12 @@
 
 namespace ChatWork\OAuth2\Client\Test;
 
+require 'vendor/phpunit/phpunit/src/Framework/Assert/Functions.php';
+
 use ChatWork\OAuth2\Client\ChatWorkProvider;
+use League\OAuth2\Client\Grant\AuthorizationCode;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * @package ChatWork\OAuth2\Client\Test
@@ -28,4 +32,43 @@ class ChatWorkProviderTest extends TestCase
 
         $this->assertNotNull($provider->getState());
     }
+
+    /**
+     * @test
+     */
+    public function getAccessToken_willSendClientIdByHeader()
+    {
+        $clientId       = 'test_client_id';
+        $clientSecret   = 'test_client_secret';
+        $expectedToken  = base64_encode("{$clientId}:{$clientSecret}");
+
+        $assert = function (RequestInterface $request) use ($expectedToken) {
+            parse_str($request->getBody()->getContents(), $param);
+            assertArrayNotHasKey('client_id', $param,       'request body should not contains "client_id".');
+            assertArrayNotHasKey('client_secret', $param,   'request body should not contains "client_secret" too.');
+            assertEquals("Basic {$expectedToken}", $request->getHeader('Authorization')[0], 'client MUST use Basic Authentication');
+            throw new \Exception('OK'); // stop before send request
+        };
+
+        $this->expectExceptionMessage('OK');
+
+        $provider = new ChatWorkProvider(
+            $clientId, 
+            $clientSecret, 
+            'https://example.com/',
+            [
+                'httpClient' => $this->createSpyClient($assert)
+            ]
+        );
+        
+        $provider->getAccessToken(new AuthorizationCode(), ['code' => 'authorization_code']);
+    }
+
+    private function createSpyClient(callable $assetion)
+    {
+        $stack = \GuzzleHttp\HandlerStack::create();
+        $stack->push(\GuzzleHttp\Middleware::tap($assetion));
+        return new \GuzzleHttp\Client(['handler' => $stack]);
+    }
+    
 }


### PR DESCRIPTION
# What I found

This library overrides `League\OAuth2\Client\Provider\AbstractProvider::getAccessTokenBody` method.
That method was removed in `league/oauth2-client` v2.4.0.
(https://github.com/thephpleague/oauth2-client/blob/2.4.0/src/Provider/AbstractProvider.php)

So it broke.
When call `$provider->getAccessToken()`, Chatwork Authorization Server returns error, like this; 

`{"error":"invalid_client","error_description":"The client type is invalid.","error_uri":null}`

and library throws `League\OAuth2\Client\Provider\Exception\IdentityProviderException`.

# What I do

- Fix `league/oauth2-client` version to '>=2.2.0 <2.4.0`.
- Add test case.
- Add GitHub Actions setting.