### PR TITLE
chore(CI): execute CI when pull request from fork repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: ci
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   run-phpunit:


### PR DESCRIPTION
# Motivation

GitHub Actions are not working on Pull Request from fork repository. We would like to confirm that it works, so that we can merge safely.

# Changes

Changed to run CI on pull request event instead of push event. master branch is still running to check the status after merge.