### PR TITLE
chore: enable DependaBot Version Updates for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      time: "08:00"
+      timezone: "Asia/Tokyo"


### PR DESCRIPTION
# backgroud

[GitHub Announced  actions runner using node20 instead of node16](https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/).

We want to avoid problems in advance. To this end, we will implement a mechanism to update actions so that they can be simply updated.
The aim is to eventually update problematic actions.

Also, DependaBot is used because it is an official GitHub feature.