### PR TITLE
ci: add PHP 8.3, 8.4, and 8.5 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
         phpunit: [9]
         composer: [2]
         include:


### PR DESCRIPTION
## Summary
- Add PHP 8.3, 8.4, and 8.5 to the CI test matrix
- These versions use PHPUnit 9 and Composer 2, consistent with existing PHP 8.x entries

## Test plan
- [x] Verify CI runs successfully for PHP 8.3, 8.4, and 8.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)